### PR TITLE
fix: support Windows in npm metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   },
   "os": [
     "darwin",
-    "linux"
+    "linux",
+    "win32"
   ],
   "dependencies": {},
   "devDependencies": {}


### PR DESCRIPTION
## What
Add win32 to package.json os so npm/npx on Windows no longer rejects installation with EBADPLATFORM.

## Why
bin/argo.js already handles win32 (uses python), and the Python MCP server runs on Windows. Only package metadata blocked official npx and the DSH bundle default path.

## Verification
- npx no longer hits EBADPLATFORM on Windows after the fix.
- python scripts/mcp_server.py responds to MCP initialize on Windows.