### PR TITLE
docs: fix DeepSeek Harness override example

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ npx -y github:taxueseek/argo
 dsh plugin --profile web add "github:taxueseek/argo#main&path:packages/dsh-plugin"
 ```
 
-重启 `dsh web` 后生效。包结构见 `packages/dsh-plugin/`；同 id `mcp-argo` 可在用户层 `cordis.patch.yml` 覆盖（如改用本地源码路径）。
+重启 `dsh web` 后生效。包结构见 `packages/dsh-plugin/`；如需改用本地源码路径，在用户层 `cordis.patch.yml` 使用非 insert 的 id 定向覆盖（不要再用 `insert` 追加同 id 行），完整示例见 `packages/dsh-plugin/README.md`。
 
 ### 依赖清单（通俗版）
 

--- a/packages/dsh-plugin/README.md
+++ b/packages/dsh-plugin/README.md
@@ -19,21 +19,27 @@ dsh plugin --profile web add "github:taxueseek/argo#main&path:packages/dsh-plugi
 
 ## 自定义（可选）
 
-本插件的配置行 id 为 `mcp-argo`。如需改用本地 argo 源码（更快、离线可用），在 profile 的 `cordis.patch.yml` 用户层覆盖：
+本插件的配置行 id 为 `mcp-argo`。如需改用本地 argo 源码（更快、离线可用），在 profile 的 `cordis.patch.yml` 用户层用**非 insert 的 id 定向覆盖**：
 
 ```yaml
-- insert:
-    - id: mcp-argo
-      name: '@deepseek-ai/dsh-mcp-client'
-      config:
-        serverName: argo
-        transport: stdio
-        command: /usr/bin/python3
-        args:
-          - /path/to/argo/scripts/mcp_server.py
+- id: mcp-argo
+  name: '@deepseek-ai/dsh-mcp-client'
+  config:
+    serverName: argo
+    transport: stdio
+    command: python
+    args:
+      - C:/path/to/argo/scripts/mcp_server.py
+    toolCallTimeoutMs: 180000
+    failOnStartupError: true
 ```
 
-Cordis patch 语义：用户层同 id 最后写入者胜，覆盖插件默认配置。
+注意：
+- 覆盖 patch 必须写成上面的顶层 `id` 形式，不能再用 `- insert: - id: mcp-argo`。`insert` 只会追加或向 group 追加，不会替换同 id 行；追加第二条 `mcp-argo` 会在 DSH loader 中触发 `duplicate loader entry id` 并导致 profile 启动失败。
+- `name` 必须与 bundle 行完全一致，否则覆盖会被跳过。
+- `config` 是整体替换，必须写全 `serverName`、`transport`、`command`、`args`。
+- Windows 使用 `command: python`；macOS/Linux 可替换为 `/usr/bin/python3`。
+- 如果不想安装 bundle，也可以直接用唯一 id（如 `mcp-argo-local`）通过 `insert` 创建这行，不要与 bundle 的 `mcp-argo` 混用同一个 `serverName`。
 
 ## 卸载
 

--- a/packages/dsh-plugin/cordis.patch.yml
+++ b/packages/dsh-plugin/cordis.patch.yml
@@ -4,9 +4,20 @@
 # 工具经 @deepseek-ai/dsh-mcp-client 注册，模型可见 mcp__argo__* 系列。
 # 安装后重启 dsh web 生效。
 #
-# 提示：同 id（mcp-argo）可在用户层 cordis.patch.yml 覆盖本配置，
-# 例如改用本地源码路径（python3 /path/to/argo/scripts/mcp_server.py），
-# 用户层同 id 最后写入者胜。
+# 提示：如需在用户层 cordis.patch.yml 覆盖本配置（例如改用本地源码路径），
+# 必须使用非 insert 的 id 定向覆盖，不能再用 insert 追加同 id 行：
+#
+#   - id: mcp-argo
+#     name: '@deepseek-ai/dsh-mcp-client'
+#     config:
+#       serverName: argo
+#       transport: stdio
+#       command: python
+#       args:
+#         - C:/path/to/argo/scripts/mcp_server.py
+#
+# 再写 `- insert: - id: mcp-argo` 会追加第二条 mcp-argo，DSH loader 检测到
+# 重复 id 会抛 `duplicate loader entry id` 并导致 profile 启动失败。
 
 - insert:
     - id: mcp-argo


### PR DESCRIPTION
## What
Fix DSH bundle docs that told users to override mcp-argo with an insert of the same id.

## Why
DSH 0.1.0-rc.6 insert semantics append rows; adding a second mcp-argo triggers duplicate loader entry id and prevents profile startup. The correct form is a non-insert id-targeted patch.

## Changes
- packages/dsh-plugin/README.md: correct override example and notes.
- packages/dsh-plugin/cordis.patch.yml: fix misleading comment.
- README.md: point to correct override docs.