### PR TITLE
fix: include engines and data in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   "files": [
     "bin/",
     "scripts/",
+    "engines/",
+    "data/",
     "config.yaml",
     "backends/",
     "sub-skills/",


### PR DESCRIPTION
## What
Include engines/ and data/ in the npm package files whitelist.

## Why
Runtime loads engines/specs and data files such as job region/country data. They are currently omitted from the npm package, so npx installs silently lose external engine specs and job data.

## Verification
- npm pack includes engines/ and data/.
- npx install no longer misses those paths.