### PR TITLE
fix: Windows runtime — GBK encoding & cross-platform tool detection

### DIFF
--- a/bin/argo.js
+++ b/bin/argo.js
@@ -24,7 +24,7 @@ if (!fs.existsSync(SCRIPT)) {
 
 const proc = spawn(PYTHON, [SCRIPT], {
   stdio: ['pipe', 'pipe', 'inherit'],
-  env: { ...process.env },
+  env: { ...process.env, PYTHONUTF8: '1' },
 });
 
 process.stdin.pipe(proc.stdin);

--- a/scripts/argo_engine_registry.py
+++ b/scripts/argo_engine_registry.py
@@ -72,7 +72,7 @@ class EngineRegistry:
     def _load_health(self):
         if HEALTH_STATE_PATH.exists():
             try:
-                self._health = json.loads(HEALTH_STATE_PATH.read_text())
+                self._health = json.loads(HEALTH_STATE_PATH.read_bytes())
             except Exception:
                 self._health = {}
 

--- a/scripts/engines_base.py
+++ b/scripts/engines_base.py
@@ -71,7 +71,8 @@ def safe_search(fn: Callable) -> Callable:
 def _run(cmd: list[str], timeout: float = 8, engine_name: str = "?") -> str:
     """执行命令，超时/异常不抛。"""
     try:
-        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        r = subprocess.run(cmd, capture_output=True, text=True,
+                           encoding="utf-8", errors="replace", timeout=timeout)
         if r.returncode == 0:
             return r.stdout
         tail = (r.stderr or "").strip()[:200]

--- a/scripts/health_probe.py
+++ b/scripts/health_probe.py
@@ -85,8 +85,8 @@ def _probe_cli(cmd: list[str], timeout: float = 2) -> tuple[bool, float, str]:
     if isinstance(exe, str) and exe.startswith("~"):
         exe = str(Path(exe).expanduser())
     try:
-        result = subprocess.run(["which", exe], capture_output=True, text=True, timeout=timeout)
-        if result.returncode == 0:
+        import shutil
+        if shutil.which(exe):
             return True, 0, ""
         return False, 0, f"command not found: {exe}"
     except Exception as e:

--- a/scripts/mcp_server.py
+++ b/scripts/mcp_server.py
@@ -109,6 +109,10 @@ def test_mode():
 # ── 入口 ──────────────────────────────────────────────────────────────────────
 
 if __name__ == "__main__":
+    if os.name == "nt" and not sys.flags.utf8_mode:
+        os.execv(sys.executable,
+                 [sys.executable, "-X", "utf8", os.path.abspath(__file__)]
+                 + sys.argv[1:])
     if "--test" in sys.argv:
         test_mode()
     else:

--- a/scripts/mcp_transport.py
+++ b/scripts/mcp_transport.py
@@ -112,6 +112,8 @@ def run_stdio():
 
         except json.JSONDecodeError:
             _send_error(None, -32700, "Parse error")
+        except KeyboardInterrupt:
+            break
         except Exception as e:
             _send_error(None, -32000, f"Internal error: {e}")
 

--- a/scripts/quota.py
+++ b/scripts/quota.py
@@ -41,14 +41,14 @@ class QuotaManager:
     def _load_profiles(self) -> None:
         if QUOTA_PROFILES_PATH.exists():
             try:
-                self._profiles = json.loads(QUOTA_PROFILES_PATH.read_text())
+                self._profiles = json.loads(QUOTA_PROFILES_PATH.read_bytes())
             except (json.JSONDecodeError, OSError):
                 self._profiles = {}
 
     def _load_state(self) -> None:
         if QUOTA_STATE_PATH.exists():
             try:
-                self._state = json.loads(QUOTA_STATE_PATH.read_text())
+                self._state = json.loads(QUOTA_STATE_PATH.read_bytes())
             except (json.JSONDecodeError, OSError):
                 self._state = {}
 

--- a/scripts/tfidf_router.py
+++ b/scripts/tfidf_router.py
@@ -120,7 +120,7 @@ def _load_quota_state() -> dict:
     if _quota_state_cache is not None and mtime == _quota_state_mtime:
         return _quota_state_cache
     try:
-        data = json.loads(quota_path.read_text())
+        data = json.loads(quota_path.read_bytes())
     except (json.JSONDecodeError, OSError):
         data = {}
     _quota_state_cache = data if isinstance(data, dict) else {}
@@ -151,7 +151,7 @@ def _load_cost_profiles() -> dict:
     if _cost_profiles_cache is not None and mtime == _cost_profiles_mtime:
         return _cost_profiles_cache
     try:
-        data = json.loads(tiers_path.read_text())
+        data = json.loads(tiers_path.read_bytes())
     except (json.JSONDecodeError, OSError):
         data = {}
     _cost_profiles_cache = data if isinstance(data, dict) else {}
@@ -191,7 +191,7 @@ class SemanticRouter:
             self._loaded = True
             return
         try:
-            profiles = json.loads(DOMAIN_PROFILES_PATH.read_text())
+            profiles = json.loads(DOMAIN_PROFILES_PATH.read_bytes())
         except (json.JSONDecodeError, OSError):
             self._loaded = True
             return

--- a/sub-skills/local-seek/scripts/seek.py
+++ b/sub-skills/local-seek/scripts/seek.py
@@ -37,6 +37,7 @@ import argparse
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import time
@@ -81,7 +82,7 @@ def pcre2_supported() -> bool:
     """本机 rg 是否编译了 pcre2 特性（模块级缓存，只测一次）。"""
     global _pcre2_ok
     if _pcre2_ok is None:
-        proc = run(["rg", "--pcre2", "-e", "x", "/dev/null"])
+        proc = run(["rg", "--pcre2", "-e", "x", os.devnull])
         _pcre2_ok = proc is not None and proc.returncode == 0
     return _pcre2_ok
 
@@ -149,6 +150,7 @@ def load_excludes() -> list:
 def run(cmd, cwd=None, timeout=30):
     try:
         return subprocess.run(cmd, capture_output=True, text=True,
+                              encoding="utf-8", errors="replace",
                               cwd=cwd, timeout=timeout)
     except subprocess.TimeoutExpired:
         return None
@@ -157,8 +159,7 @@ def run(cmd, cwd=None, timeout=30):
 
 
 def tool_exists(name: str) -> bool:
-    proc = run(["command", "-v", name])
-    return proc is not None and proc.returncode == 0
+    return shutil.which(name) is not None
 
 
 def truncate(text: str, n: int = 120) -> str:
@@ -237,6 +238,75 @@ def fd_search(query, path, exts, max_results):
     if proc is None or proc.returncode not in (0, 1):
         return [], "fd 执行失败"
     out = [(p, 0, "") for p in proc.stdout.splitlines()[:max_results]]
+    return out, None
+
+
+def resolve_grep():
+    p = shutil.which("grep")
+    if p:
+        return p
+    if os.name == "nt":
+        git = shutil.which("git")
+        if git:
+            cand = Path(git).resolve().parent.parent / "usr" / "bin" / "grep.exe"
+            if cand.exists():
+                return str(cand)
+    return None
+
+
+def grep_search(grep_exe, patterns, path, excludes, exts, context, count,
+                max_results, fixed, raw_query=""):
+    def build(fixed):
+        cmd = [grep_exe, "-r", "-n", "-i", "-I", "--color=never"]
+        if fixed:
+            cmd.append("-F")
+        elif needs_pcre2(raw_query):
+            return None, ("grep 不支持 look-around/反向引用语法，"
+                          "请简化查询（如去掉 (?=、(?! 等结构）或安装 ripgrep")
+        if count:
+            cmd.append("--count-matches")
+        elif context > 0:
+            cmd += ["-C", str(context)]
+        for ex in excludes:
+            if any(c in ex for c in "*?["):
+                cmd += ["--exclude", ex]
+            else:
+                cmd += ["--exclude-dir", ex]
+        if exts:
+            for e in exts:
+                cmd += ["--include", f"*.{e}"]
+        for p in patterns:
+            cmd += ["-e", p]
+        cmd.append(str(path))
+        return cmd, None
+
+    cmd, err = build(fixed)
+    if err:
+        return [], err
+    proc = run(cmd)
+    if (proc is not None and proc.returncode == 2 and not fixed
+            and "grep:" in (proc.stderr or "")):
+        cmd2, _ = build(True)
+        proc = run(cmd2)
+    if proc is None or proc.returncode not in (0, 1, 2):
+        return [], "grep 执行失败"
+    if proc.returncode == 1:
+        return [], None
+    out = []
+    for line in proc.stdout.splitlines():
+        if count:
+            if ":" in line:
+                fp, _, n = line.rpartition(":")
+                out.append((fp, int(n) if n.isdigit() else 0, ""))
+            if len(out) >= max_results:
+                break
+        else:
+            m = re.match(r"^(.*?):(\d+):(.*)$", line)
+            if m:
+                fp, ln, txt = m.group(1), int(m.group(2)), m.group(3)
+                out.append((fp, ln, truncate(txt)))
+            if len(out) >= max_results:
+                break
     return out, None
 
 
@@ -649,12 +719,40 @@ def main():
     patterns, fixed = build_patterns(args.query, args.exact)
 
     if scope == "all" or not tool_exists("rg"):
-        engine, mode = "mdfind", "deep"
-        results, err = mdfind_search(args.query, None if args.spotlight else path,
-                                     max_results)
+        if tool_exists("mdfind"):
+            engine, mode = "mdfind", "deep"
+            results, err = mdfind_search(args.query,
+                                         None if args.spotlight else path,
+                                         max_results)
+        else:
+            grep_exe = resolve_grep()
+            if grep_exe:
+                engine, mode = "grep", "fast"
+                if not args.exact and len(patterns) > 1:
+                    results, err = grep_search(grep_exe, [args.query], path,
+                                               excludes, exts, args.context,
+                                               args.count, max_results,
+                                               is_literal(args.query))
+                    if not results and not err:
+                        results, err = grep_search(grep_exe, patterns, path,
+                                                   excludes, exts,
+                                                   args.context, args.count,
+                                                   max_results, fixed)
+                        if results:
+                            mode += "+扩展"
+                else:
+                    results, err = grep_search(grep_exe, patterns, path,
+                                               excludes, exts, args.context,
+                                               args.count, max_results, fixed)
+            else:
+                engine, mode = "none", "fast"
+                err = "本机无 rg/mdfind/grep 可用，请安装 ripgrep"
     elif args.filename:
         engine, mode = "fd", "fast"
-        results, err = fd_search(args.query, path, exts, max_results)
+        if tool_exists("fd"):
+            results, err = fd_search(args.query, path, exts, max_results)
+        else:
+            err = "fd 未安装：按文件名搜索需要 fd（内容搜索走 rg/grep）"
     else:
         mode = "deep" if (args.context > 0 or args.count) else "fast"
         if not args.exact and len(patterns) > 1:
@@ -694,4 +792,10 @@ def main():
 
 
 if __name__ == "__main__":
+    for _s in (sys.stdout, sys.stderr):
+        try:
+            if _s.encoding and _s.encoding.lower().replace("-", "") != "utf8":
+                _s.reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass
     sys.exit(main())


### PR DESCRIPTION
## What

Make argo actually run on Windows (win11 + Python 3.12, npm-installed package).

- `bin/argo.js`: spawn env 注入 `PYTHONUTF8=1`（PEP 540 UTF-8 模式），官方入口下所有子进程文件读写/解码统一 UTF-8
- `scripts/mcp_server.py`: 入口 re-exec 守卫 —— 直接 `python mcp_server.py` 且非 UTF-8 模式时 `execv` 自身加 `-X utf8`（stdio 句柄继承，管道语义不变）
- `tfidf_router.py` / `quota.py` / `argo_engine_registry.py`: 6 处含中文 JSON 读取 `read_text()` → `read_bytes()`（JSON 规范自检编码，还能吃 BOM）
- `sub-skills/local-seek/scripts/seek.py`:
  - `tool_exists` 由 Unix shell 内建 `command -v` 改为 `shutil.which`（Windows 下 `command` 不存在，导致永远误判 rg 缺失而落到 macOS 专属的 mdfind）
  - `/dev/null` → `os.devnull`
  - 无 rg 时的兜底由 mdfind 改为 GNU grep 递归：PATH 优先，Windows 下自动探测 Git for Windows 自带的 `usr/bin/grep.exe`；输出与 `rg --no-heading` 同构复用解析；正则失败回退 `-F`
  - 入口重配 stdout/stderr 为 UTF-8；中央 `run()` 显式 `encoding="utf-8", errors="replace"`（库导入 / CLI 直跑形态的独立防线）
- `health_probe.py`: `which` 命令探测改为 `shutil.which`

## Why

npm 安装后在 Windows 上 argo_search 直接崩溃：

```
UnicodeDecodeError: 'gbk' codec can't decode byte 0xa2 in position 37
```

根因是 Windows 默认 locale 编码 GBK：`read_text()` 读含中文的 `backends/*.json` 即崩，且 `UnicodeDecodeError` 不在原有 `except (JSONDecodeError, OSError)` 捕获范围，异常穿透到顶层。argo_local_search 则因 `command -v` / `mdfind` 双失效完全不可用。

设计取舍：入口级 UTF-8 模式（2 个入口）+ 字节流读取（6 处）+ 中央 helper 显式 encoding（2 处），而非 16 处散点 hardcode——新增代码自动免疫，diff 最小，且 Python 3.15 起 UTF-8 模式成为默认（PEP 686），届时守卫自然变 no-op。macOS/Linux 行为不变（grep 兜底仅在 rg 与 mdfind 均缺失时触达）。

Complements #2（os 元数据）——#2 解决装得上，本 PR 解决跑得动。

## Tested

- 7 个 py 文件 `py_compile` + `node --check` 通过
- MCP 直跑（re-exec 生效，双启动 banner）：`argo_search` 中文查询返回真实结果（L3 引擎恢复生效），无 GBK 错误；`argo_local_search` 114ms 命中且行号精确
- `node bin/argo.js` 入口：env 传播生效（单 banner，守卫 no-op），initialize 正常
- seek 引擎矩阵：正常 PATH 走 rg；剥除 rg 后经 Git 推导 grep（3 处命中行号精确）；中文 17 字查询 JSON snippet 端到端无损；rg/grep/git 全无时优雅报错

---

*Created from DSH session; branch `fix/windows-runtime`, single commit `52cb7e8`.*