### PR TITLE
fix: _find_chrome() add Windows Chrome/Edge/CHROME_PATH detection

### DIFF
--- a/scripts/chrome_cdp.py
+++ b/scripts/chrome_cdp.py
@@ -307,16 +307,41 @@ class _ChromeProcess:
 
     @staticmethod
     def _find_chrome() -> str:
+        # 环境变量优先（用户/宿主显式指定）
+        env_path = os.environ.get("CHROME_PATH") or os.environ.get("chrome_path")
+        if env_path and os.path.isfile(env_path):
+            return env_path
+
         candidates = [
+            # macOS
             "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
             "/Applications/Chromium.app/Contents/MacOS/Chromium",
+            # Linux
             "/usr/bin/google-chrome",
             "/usr/bin/chromium",
+            "/usr/bin/google-chrome-stable",
+            "/snap/bin/chromium",
+            # Windows (x64)
+            r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+            # Windows (x86)
+            r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
+            # Windows user-local
+            os.path.join(os.environ.get("LOCALAPPDATA", ""), "Google", "Chrome", "Application", "chrome.exe"),
+            # Edge (Chromium-based, 作为 Windows 默认浏览器回退)
+            r"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe",
         ]
         for c in candidates:
-            if os.path.isfile(c):
+            if c and os.path.isfile(c):
                 return c
-        raise FileNotFoundError("Chrome not found. Install Chrome or set chrome_path.")
+
+        # Windows: 尝试从 PATH 查找
+        import shutil
+        for name in ("chrome.exe", "chromium.exe", "msedge.exe"):
+            found = shutil.which(name)
+            if found:
+                return found
+
+        raise FileNotFoundError("Chrome not found. Install Chrome or set CHROME_PATH env var.")
 
     def start(self) -> None:
         """启动 headless Chrome with remote debugging。"""


### PR DESCRIPTION
## Problem

`_ChromeProcess._find_chrome()` in `scripts/chrome_cdp.py` only searches macOS and Linux paths. On Windows it always raises `FileNotFoundError: Chrome not found`, even when Chrome is installed at the standard location `C:\Program Files\Google\Chrome\Application\chrome.exe`. This breaks the browser-fetch fallback on Windows users — which silently disables the `fetch_v3` Level 2 (Chrome CDP) and `robots.txt → browser` degradation path.

## Fix

Add Windows discovery paths and an explicit override environment variable:

- `CHROME_PATH` / `chrome_path` env vars take precedence
- Windows Chrome (x64, x86, user-local `%LOCALAPPDATA%`)
- Edge (Chromium-based) as a Windows fallback
- `shutil.which()` last-resort scan of `PATH`

## Diff (key part)

```python
candidates = [
    # macOS
    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
    "/Applications/Chromium.app/Contents/MacOS/Chromium",
    # Linux
    "/usr/bin/google-chrome",
    "/usr/bin/chromium",
    "/usr/bin/google-chrome-stable",
    "/snap/bin/chromium",
    # Windows (x64)
    r"C:\Program Files\Google\Chrome\Application\chrome.exe",
    # Windows (x86)
    r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
    # Windows user-local
    os.path.join(os.environ.get("LOCALAPPDATA", ""), "Google", "Chrome", "Application", "chrome.exe"),
    # Edge (Chromium-based)
    r"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe",
]
```

## Test

On a Windows 11 machine with Chrome at the standard path:

```
>>> from chrome_cdp import _ChromeProcess
>>> _ChromeProcess().chrome_path
'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe'
>>> os.path.isfile(_ChromeProcess().chrome_path)
True
```

Verified end-to-end via `fetch_v3.fetch_v3()` against `https://baike.baidu.com/item/酷态科/64079235` (a URL blocked by `robots.txt` with `User-agent: * Disallow: /`): now degrades to Chrome CDP and returns 6347 chars of content with `fetch_method="chrome_cdp"`. Without this fix, it raised `Chrome not found`.

## Notes

- Existing macOS/Linux behavior is unchanged.
- The override error message now mentions `CHROME_PATH` for clarity.
- No new dependencies; `os` and `shutil` are stdlib.
