### PR TITLE
fix: remove os field blocking Windows installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,6 @@
   "engines": {
     "node": ">=18"
   },
-  "os": [
-    "darwin",
-    "linux"
-  ],
   "dependencies": {},
   "devDependencies": {}
 }


### PR DESCRIPTION
Windows 下 npx -y github:taxueseek/argo 直接失败：
npm error code EBADPLATFORM
npm error notsup Unsupported platform for argo-search@2.8.0: wanted {"os":"darwin,linux"} (current: {"os":"win32"})

Removes the `"os": ["darwin", "linux"]` restriction from `package.json`. The code already supports Windows (`bin/argo.js` explicitly branches on `win32`), so this metadata-only change unlocks installs and `npx github:taxueseek/argo` on Windows.

On Windows, the officially recommended install command fails immediately at npm's platform check:
PS C:> npx -y github:taxueseek/argo npm error code EBADPLATFORM npm error notsup Unsupported platform for argo-search@2.8.0: wanted {"os":"darwin,linux"} (current: {"os":"win32"}) npm error notsup Valid os: darwin,linux npm error notsup Actual os: win32


 Root cause

`package.json` declares `"os": ["darwin", "linux"]`, but the package has **zero native dependencies** (`"dependencies": {}`) and the entry script explicitly handles Windows:

```js
// bin/argo.js
return process.platform === 'win32' ? 'python' : 'python3';

Runtime requirement is Python 3.10+ with PyYAML, which is platform-independent. The os field contradicts the actual code support.