### PR TITLE
fix: Windows compatibility for macOS-specific paths and tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,18 @@ freshness  ≈ 发布时间（会忽略「2015 年以来」这类历史对比年
 
 ### 方式一：一键脚本（推荐本机长期用）
 
+macOS / Linux：
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/taxueseek/argo/main/scripts/install.sh | bash
+```
+
+Windows（PowerShell）：
+
+```powershell
+powershell -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/taxueseek/argo/main/scripts/install.ps1 | iex"
+# 或下载后执行：
+# powershell -ExecutionPolicy Bypass -File scripts/install.ps1
 ```
 
 装到指定目录、并挂 Skill 入口：

--- a/scripts/chrome_cdp.py
+++ b/scripts/chrome_cdp.py
@@ -32,6 +32,7 @@ import json
 import socket
 import ssl
 import subprocess
+import tempfile
 import time
 import os
 import signal
@@ -297,7 +298,9 @@ class _ChromeProcess:
         self.port = port or self._find_free_port()
         self.chrome_path = chrome_path or self._find_chrome()
         self._proc: subprocess.Popen | None = None
-        self._user_data_dir = f"/tmp/argo_chrome_{self.port}"
+        # 跨平台：/tmp 在 Windows 不存在，统一用系统临时目录
+        self._user_data_dir = os.path.join(
+            tempfile.gettempdir(), f"argo_chrome_{self.port}")
 
     @staticmethod
     def _find_free_port() -> int:
@@ -615,7 +618,8 @@ class ChromeCDP:
         if r and "data" in r:
             import base64
             data = base64.b64decode(r["data"])
-            path = path or f"/tmp/argo_screenshot_{int(time.time())}.png"
+            path = path or os.path.join(
+                tempfile.gettempdir(), f"argo_screenshot_{int(time.time())}.png")
             with open(path, "wb") as f:
                 f.write(data)
             if full_page:

--- a/scripts/engines_base.py
+++ b/scripts/engines_base.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import subprocess
 import sys
 import time
@@ -235,6 +236,10 @@ def _build_cli_engine(spec: dict[str, Any]) -> Any:
         args = _resolve(search_args, query, n, mode=mode, **kwargs)
         if not cmd:
             return []
+        # 跨平台解释器解析：Windows 一般没有 python3 这个可执行名
+        if isinstance(cmd, list) and cmd and cmd[0] == "python3":
+            py3 = shutil.which("python3") or shutil.which("python") or sys.executable
+            cmd[0] = py3
         for key, tmpl in filter_args.items():
             if kwargs.get(key) not in (None, ""):
                 args += _resolve(tmpl, query, n, mode=mode, **kwargs)
@@ -419,7 +424,8 @@ def _load_parse_maps() -> dict:
         return {}
     try:
         import yaml
-        with open(maps_path) as f:
+        # Windows 下 locale 默认编码（GBK）会读崩 UTF-8 的 YAML，必须显式声明
+        with open(maps_path, encoding="utf-8") as f:
             return yaml.safe_load(f) or {}
     except Exception:
         return {}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,114 @@
+# Argo 一键安装脚本（Windows PowerShell 版）
+# 与 install.sh 对齐：克隆/更新真源 + 依赖 + 可选 Skill 链接
+# 用法：
+#   powershell -ExecutionPolicy Bypass -File scripts/install.ps1
+#   $env:ARGO_HOME = "C:\path\to\argo"; powershell -ExecutionPolicy Bypass -File scripts/install.ps1
+#
+# 环境变量：
+#   ARGO_HOME         安装目录，默认 $env:USERPROFILE\.local\share\argo
+#   ARGO_REPO         仓库地址，默认 https://github.com/taxueseek/argo.git
+#   ARGO_BRANCH       分支，默认 main
+#   ARGO_SKIP_PIP     设为 1 则跳过 pip 安装
+#   ARGO_LINK_TARGETS 分号分隔的 Skill 入口路径（可选）
+
+$ErrorActionPreference = "Stop"
+
+$Repo = if ($env:ARGO_REPO) { $env:ARGO_REPO } else { "https://github.com/taxueseek/argo.git" }
+$Branch = if ($env:ARGO_BRANCH) { $env:ARGO_BRANCH } else { "main" }
+$InstallDir = if ($env:ARGO_HOME) { $env:ARGO_HOME } else { Join-Path $env:USERPROFILE ".local\share\argo" }
+$SkipPip = ($env:ARGO_SKIP_PIP -eq "1")
+$LinkTargets = @()
+foreach ($a in $args) {
+    if ($a -eq "--link" -or $a -eq "--to") { continue }
+    if ($args -contains $a) { continue }  # --to 的值在下一轮处理
+    $LinkTargets += $a
+}
+# 简单解析 --to <path>
+for ($i = 0; $i -lt $args.Count; $i++) {
+    if ($args[$i] -eq "--to") { $LinkTargets += $args[$i + 1] }
+}
+if ($env:ARGO_LINK_TARGETS) {
+    $LinkTargets += ($env:ARGO_LINK_TARGETS -split ";")
+}
+
+Write-Host "==> Argo 安装目录: $InstallDir"
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Write-Error "需要 git，请先安装后再试。"
+    exit 1
+}
+if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+    Write-Error "需要 Python 3.10+，请先安装后再试。"
+    exit 1
+}
+
+$pyOk = python -c "import sys; print(1 if sys.version_info >= (3, 10) else 0)"
+if ($pyOk.Trim() -ne "1") {
+    Write-Error "当前 Python 版本低于 3.10。"
+    exit 1
+}
+
+if (Test-Path (Join-Path $InstallDir ".git")) {
+    Write-Host "==> 已有仓库，拉取更新 ($Branch)…"
+    git -C $InstallDir fetch --depth 1 origin $Branch
+    git -C $InstallDir checkout $Branch
+    git -C $InstallDir pull --ff-only origin $Branch
+    if ($LASTEXITCODE -ne 0) { Write-Host "[warn] pull --ff-only 失败，跳过" }
+} elseif ((Test-Path $InstallDir) -and (Test-Path (Join-Path $InstallDir "scripts\search.py"))) {
+    Write-Host "==> 目录已存在且含 Argo 源码，跳过克隆: $InstallDir"
+} else {
+    Write-Host "==> 克隆仓库…"
+    New-Item -ItemType Directory -Force -Path (Split-Path $InstallDir) | Out-Null
+    git clone --depth 1 --branch $Branch $Repo $InstallDir
+}
+
+if (-not $SkipPip) {
+    Write-Host "==> 安装依赖 (PyYAML)…"
+    python -m pip install pyyaml
+    if ($LASTEXITCODE -ne 0) { Write-Host "[warn] pip 安装 PyYAML 失败，可手动: pip install pyyaml" }
+    Write-Host "==> 安装可选增强 (curl_cffi: TLS 指纹伪造，缺失不影响核心功能)…"
+    python -m pip install curl_cffi
+    if ($LASTEXITCODE -ne 0) { Write-Host "[warn] pip 安装 curl_cffi 失败（可选依赖）" }
+}
+
+if ($LinkTargets.Count -gt 0 -or (Test-Path (Join-Path $InstallDir "installs.local.yaml"))) {
+    Write-Host "==> 链接 Skill 入口（符号链接回真源，不复制）…"
+    $linkArgs = @()
+    foreach ($t in $LinkTargets) { if ($t) { $linkArgs += @("--to", $t) } }
+    python (Join-Path $InstallDir "scripts\link_source.py") @linkArgs
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "[warn] 链接未完成。可稍后手动:"
+        Write-Host "  python $InstallDir\scripts\link_source.py --to C:\Users\you\.claude\skills\argo"
+    }
+}
+
+Write-Host ""
+Write-Host "==> 安装完成"
+Write-Host ""
+Write-Host "快速验证:"
+Write-Host "  python $InstallDir\scripts\search.py ""Python asyncio"" --json"
+Write-Host "  python $InstallDir\scripts\search.py --list-engines"
+Write-Host ""
+Write-Host "启动 MCP（给 Claude / Kimi / Cursor 等用）:"
+Write-Host "  python $InstallDir\scripts\mcp_server.py"
+Write-Host ""
+Write-Host "或用 npx（需 Node.js 18+）:"
+Write-Host "  npx -y argo-search"
+Write-Host ""
+Write-Host "客户端 MCP 配置示例（路径请按本机替换）:"
+Write-Host @"
+{
+  "mcpServers": {
+    "argo": {
+      "command": "python",
+      "args": ["$InstallDir\scripts\mcp_server.py"]
+    }
+  }
+}
+"@
+Write-Host ""
+Write-Host "可选：把 Skill 挂到本机 Agent 目录（不复制代码）:"
+Write-Host "  python $InstallDir\scripts\link_source.py --to $env:USERPROFILE\.claude\skills\argo"
+Write-Host "  python $InstallDir\scripts\link_source.py --to $env:USERPROFILE\.agents\skills\argo"
+Write-Host ""
+Write-Host "文档: https://github.com/taxueseek/argo"

--- a/scripts/link_source.py
+++ b/scripts/link_source.py
@@ -135,7 +135,23 @@ def link_one(target: Path, *, dry_run: bool, force: bool) -> int:
         return 0
     parent.mkdir(parents=True, exist_ok=True)
     # atomic-ish: symlink in place
-    os.symlink(source, target, target_is_directory=True)
+    try:
+        os.symlink(source, target, target_is_directory=True)
+    except OSError:
+        # Windows 无开发者模式/管理员权限时 symlink 会失败：
+        # 目录链接退化为 junction（mklink /J，不需要管理员权限），
+        # 语义与 symlink 基本一致（resolve() 同样指向真源）。
+        if os.name == "nt":
+            r = subprocess.run(
+                ["cmd", "/c", "mklink", "/J", str(target), str(source)],
+                capture_output=True, text=True,
+                encoding="utf-8", errors="replace",
+            )
+            if r.returncode == 0 and _is_link_to_source(target):
+                print(f"[link] {target} -> {source} (junction)")
+                return 0
+        print(f"[fail] 创建链接失败: {target} -> {source}", file=sys.stderr)
+        return 1
     print(f"[link] {target} -> {source}")
     return 0
 

--- a/scripts/mcp_handlers.py
+++ b/scripts/mcp_handlers.py
@@ -16,6 +16,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import threading
 from typing import Any
 
@@ -792,7 +793,8 @@ def execute_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
 
         elif name == "argo_screenshot":
             import time as _time
-            output = arguments.get("output_path", f"/tmp/argo_screenshot_{int(_time.time())}.png")
+            output = arguments.get("output_path") or os.path.join(
+                tempfile.gettempdir(), f"argo_screenshot_{int(_time.time())}.png")
             full_page = arguments.get("full_page", False)
             try:
                 cdp_mod = _lazy_cached("chrome_cdp")

--- a/scripts/mcp_tools.py
+++ b/scripts/mcp_tools.py
@@ -164,7 +164,7 @@ TOOLS = [
             "properties": {
                 "url": {"type": "string", "description": "目标 URL"},
                 "full_page": {"type": "boolean", "description": "全页截图（默认仅当前视口）", "default": False},
-                "output_path": {"type": "string", "description": "输出路径（默认 /tmp/argo_screenshot_<timestamp>.png）"},
+                "output_path": {"type": "string", "description": "输出路径（默认写入系统临时目录：<temp>/argo_screenshot_<timestamp>.png）"},
             },
             "required": ["url"],
         },

--- a/sub-skills/local-seek/SKILL.md
+++ b/sub-skills/local-seek/SKILL.md
@@ -57,7 +57,7 @@ python3 sub-skills/local-seek/scripts/seek.py --git-blame 12 文件路径   # �
 |------|-----|--------|
 | 搜代码/正文关键词 | rg（默认） | 毫秒级，尊重 .gitignore，自动排除 node_modules 等 |
 | 只记得文件名 | --filename（fd） | 按文件名模糊匹配 |
-| 搜 PDF/邮件/已归档内容 | --spotlight（mdfind） | 走 macOS 系统索引，零成本预建 |
+| 搜 PDF/邮件/已归档内容 | --spotlight（mdfind） | 走 macOS 系统索引，零成本预建（Windows/Linux 自动退化为 rg 正文搜索） |
 | 找代码模式（裸except/空catch等） | --structural | 按语义不按字符串 |
 | 追文件历史/单行归属 | --git-log / --git-blame | 免开终端敲 git |
 | 当前目录搜不到 | 先扩大 --path，再 --spotlight | 先窄后宽 |


### PR DESCRIPTION
## 背景

本 PR 把项目中残留的 macOS 专属实现改为跨平台，使 Windows 上无需改动即可运行（已在 Windows 10/11 + Python 3.13 实测）。

## 改动清单

| 文件 | 问题 | 修复 |
|---|---|---|
| `scripts/chrome_cdp.py` | `/tmp/argo_chrome_*`、`/tmp/argo_screenshot_*` 在 Windows 不存在 | 改用 `tempfile.gettempdir()` |
| `scripts/mcp_handlers.py` | argo_screenshot 默认输出路径写死 `/tmp` | 改用系统临时目录 |
| `scripts/mcp_tools.py` | 工具描述写死 `/tmp` | 描述同步更新 |
| `scripts/engines_base.py` | `parse_maps.yaml` 用 locale 默认编码读取，Windows GBK 下 UnicodeDecodeError 导致全部 HTML 引擎解析映射静默失效 | 显式 `encoding="utf-8"` |
| `scripts/engines_base.py` | cli 引擎模板写死 `python3`（Windows 无此可执行名） | 运行时解析：`shutil.which("python3")` → `python` → `sys.executable` |
| `scripts/link_source.py` | Windows 无开发者模式/管理员权限时 `os.symlink` 抛错 | 目录链接自动退化为 junction（`mklink /J`，语义与 resolve 一致） |
| `scripts/install.ps1` | 只有 bash 版安装脚本 | 新增 PowerShell 一键安装（与 install.sh 对齐） |
| `README.md` / local-seek SKILL | 安装与文档未覆盖 Windows | 补 Windows 安装入口与 mdfind 退化说明 |

## 验证

- 全量回归（离线用例）：102 passed；1 个既有失败 `test_rrf_weighted_authority_boost` 在未改动上游 main 上同样失败，与本 PR 无关
- Windows 实测：local-seek 在无 mdfind 环境下正确退化 rg；HTML 引擎解析映射正常加载

## 说明

- 不改变 macOS/Linux 行为：平台判断只在 mdfind/junction 兜底处使用
- 无新增依赖，全部走标准库
